### PR TITLE
Add pagination for labels

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@hono/zod-validator": "^0.7.0",
     "@octokit/app": "^16.0.1",
     "@octokit/core": "^7.0.2",
+    "@octokit/plugin-paginate-rest": "^13.1.1",
     "@octokit/request-error": "^7.0.0",
     "@octokit/webhooks": "^14.1.0",
     "@sentry/cloudflare": "^9.40.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@octokit/core':
         specifier: ^7.0.2
         version: 7.0.2
+      '@octokit/plugin-paginate-rest':
+        specifier: ^13.1.1
+        version: 13.1.1(@octokit/core@7.0.2)
       '@octokit/request-error':
         specifier: ^7.0.0
         version: 7.0.0

--- a/src/services/handler.ts
+++ b/src/services/handler.ts
@@ -7,6 +7,7 @@ import { readConfig, type ConfigType } from "./config";
 import { deleteComment, updateComment } from "./comment";
 import { summarizeDiff } from "./summary";
 import { createLabels, removePRLabels, setPRLabel } from "./label";
+import { MyOctokit } from "./octokit";
 
 export async function handle(
   c: Context,
@@ -26,6 +27,7 @@ export async function handle(
   const app = new App({
     appId: c.env.GH_APP_ID,
     privateKey: c.env.GH_PRIVATE_KEY,
+    Octokit: MyOctokit,
   });
   const octo = await app.getInstallationOctokit(event.installation.id);
 

--- a/src/services/label.ts
+++ b/src/services/label.ts
@@ -2,6 +2,7 @@ import type { Octokit } from "@octokit/core";
 import type { ConfigType } from "./config";
 import { getPRInfo } from "./prinfo";
 import type { PullRequest } from "./webhook_schema";
+import type { MyOctokitInstance } from "./octokit";
 
 /**
  * Create configured issue labels from config.
@@ -12,18 +13,18 @@ import type { PullRequest } from "./webhook_schema";
  * This function will update the color for labels if that has been changed.
  */
 export async function createLabels(
-  octo: Octokit,
+  octo: MyOctokitInstance,
   pr: PullRequest,
   config: ConfigType,
 ) {
   const { owner, repo } = getPRInfo(pr);
 
-  const labels = await octo.request("GET /repos/{owner}/{repo}/labels", {
+  const labels = await octo.paginate("GET /repos/{owner}/{repo}/labels", {
     owner,
     repo,
   });
 
-  const labelMap = new Map(labels.data.map((l) => [l.name, l]));
+  const labelMap = new Map(labels.map((l) => [l.name, l]));
 
   for (const preset of config.labels) {
     const match = labelMap.get(preset.name);

--- a/src/services/octokit.ts
+++ b/src/services/octokit.ts
@@ -1,0 +1,6 @@
+import { Octokit } from "@octokit/core";
+import { paginateRest } from "@octokit/plugin-paginate-rest";
+
+export const MyOctokit = Octokit.plugin(paginateRest);
+
+export type MyOctokitInstance = InstanceType<typeof MyOctokit>;


### PR DESCRIPTION
Seeing label already exist error from time to time. Guess it's because the repository got more than 30 labels and we failed to detect existing labels in the logic.